### PR TITLE
digest2: parse_mpc80 accepts 160-column database records (v2.8.2)

### DIFF
--- a/digest2/README.md
+++ b/digest2/README.md
@@ -268,11 +268,14 @@ Notes:
 1. **MPC 80-column** (`.obs`): Fixed-width format with packed designation, date, RA/Dec, magnitude, observatory code
 2. **ADES XML** (`.xml`): Rich format with per-observation uncertainties (rmsRA, rmsDec), roving/satellite observer support
 
-The Python `parse_mpc80()` additionally accepts **160-column database
-records** (an observation line and its satellite/roving second line
-concatenated, as stored in the MPC `obs` table's `obs80` column): the second
-segment's observer position is applied automatically, so per-record database
-consumers score space-based observations correctly.
+Satellite/roving observations in the standard MPC 80-column form — an
+observation line followed by a separate `'s'`/`'v'` second line carrying the
+observer position — are fully handled by `parse_mpc80_file()`, which pairs
+sequential lines. Purely as a convenience, the Python `parse_mpc80()` also
+accepts the two lines **concatenated into a single 160-column record** (the
+form the MPC's database happens to store in its `obs80` column), applying the
+second segment's observer position automatically. Users are not required to
+use the concatenated form — sequential two-line input is equally supported.
 
 ### Config File Keywords
 

--- a/digest2/README.md
+++ b/digest2/README.md
@@ -268,6 +268,12 @@ Notes:
 1. **MPC 80-column** (`.obs`): Fixed-width format with packed designation, date, RA/Dec, magnitude, observatory code
 2. **ADES XML** (`.xml`): Rich format with per-observation uncertainties (rmsRA, rmsDec), roving/satellite observer support
 
+The Python `parse_mpc80()` additionally accepts **160-column database
+records** (an observation line and its satellite/roving second line
+concatenated, as stored in the MPC `obs` table's `obs80` column): the second
+segment's observer position is applied automatically, so per-record database
+consumers score space-based observations correctly.
+
 ### Config File Keywords
 
 | Keyword | Description |

--- a/digest2/pyproject.toml
+++ b/digest2/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "digest2"
-version = "2.8.1"
+version = "2.8.2"
 description = "NEO orbit classification from short-arc astrometric tracklets"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/digest2/src/digest2/observation.py
+++ b/digest2/src/digest2/observation.py
@@ -207,10 +207,25 @@ def _date_to_mjd(year: int, month: int, day: float) -> float:
 
 
 def parse_mpc80(line: str) -> Optional[Observation]:
-    """Parse an MPC 80-column format observation line.
+    """Parse an MPC 80-column format observation line or 160-column record.
+
+    Satellite / roving observations are stored in the MPC ``obs`` database
+    table as a single 160-column ``obs80`` value: the observation line and
+    its 's'/'v' second line (observer position) concatenated. When such a
+    record is supplied, the second segment's observer position is applied
+    and the observation is marked space-based — so database consumers (e.g.
+    the digest2-service ``/digest2_trkid`` path) score space-based
+    observations correctly instead of silently treating them as geocentric.
+
+    A record whose second segment is present but malformed (bad position
+    fields, obscode mismatch) returns None rather than degrading to a
+    geocentric observer. Trailing content after column 80 that is not an
+    's'/'v' second segment (e.g. whitespace padding) is ignored, matching
+    the previous behaviour for over-long lines.
 
     Args:
-        line: An 80-column MPC format observation line.
+        line: An 80-column MPC observation line, or a 160-column
+            first-line + second-line database record.
 
     Returns:
         Observation object, or None if the line cannot be parsed.
@@ -261,7 +276,7 @@ def parse_mpc80(line: str) -> Optional[Observation]:
 
     vmag = _update_magnitude(band, mag)
 
-    return Observation(
+    obs = Observation(
         mjd=mjd,
         ra=ra_deg,
         dec=dec_deg,
@@ -269,6 +284,15 @@ def parse_mpc80(line: str) -> Optional[Observation]:
         band=band,
         obscode=obscode,
     )
+
+    # 160-column database record: second segment note2 at column 95
+    # (index 80 + 14). Apply the observer position; reject the whole
+    # record if the second segment cannot be applied.
+    if len(line) >= 95 and line[94] in ("s", "v"):
+        if not _apply_mpc80_second_line(line[80:160].ljust(80), obs):
+            return None
+
+    return obs
 
 
 def _c_strtod(s: str) -> float:

--- a/digest2/src/digest2/observation.py
+++ b/digest2/src/digest2/observation.py
@@ -209,13 +209,21 @@ def _date_to_mjd(year: int, month: int, day: float) -> float:
 def parse_mpc80(line: str) -> Optional[Observation]:
     """Parse an MPC 80-column format observation line or 160-column record.
 
-    Satellite / roving observations are stored in the MPC ``obs`` database
-    table as a single 160-column ``obs80`` value: the observation line and
-    its 's'/'v' second line (observer position) concatenated. When such a
-    record is supplied, the second segment's observer position is applied
-    and the observation is marked space-based — so database consumers (e.g.
-    the digest2-service ``/digest2_trkid`` path) score space-based
-    observations correctly instead of silently treating them as geocentric.
+    The **standard** MPC form for satellite / roving observations is two
+    *sequential* 80-column lines — the observation line followed by a
+    separate 's'/'v' second line carrying the observer position — and that
+    form is already fully handled by :func:`parse_mpc80_file`, which pairs
+    consecutive lines. Nothing about that changes, and callers are NOT
+    required to use anything else.
+
+    Purely as a **convenience**, this function additionally accepts the two
+    lines concatenated into a single 160-column record — a form that
+    happens to be used by the MPC's database, which stores both lines in
+    one ``obs80`` value. When such a record is supplied, the second
+    segment's observer position is applied and the observation is marked
+    space-based, so per-record consumers (e.g. the digest2-service
+    ``/digest2_trkid`` path) score space-based observations correctly
+    without first splitting the record back into two lines.
 
     A record whose second segment is present but malformed (bad position
     fields, obscode mismatch) returns None rather than degrading to a
@@ -224,8 +232,8 @@ def parse_mpc80(line: str) -> Optional[Observation]:
     the previous behaviour for over-long lines.
 
     Args:
-        line: An 80-column MPC observation line, or a 160-column
-            first-line + second-line database record.
+        line: An 80-column MPC observation line, or (as a convenience) a
+            160-column first-line + second-line concatenated record.
 
     Returns:
         Observation object, or None if the line cannot be parsed.
@@ -285,9 +293,11 @@ def parse_mpc80(line: str) -> Optional[Observation]:
         obscode=obscode,
     )
 
-    # 160-column database record: second segment note2 at column 95
-    # (index 80 + 14). Apply the observer position; reject the whole
-    # record if the second segment cannot be applied.
+    # Convenience handling of a 160-column concatenated record (second
+    # segment note2 at column 95 = index 80 + 14). Sequential two-line
+    # input is handled by parse_mpc80_file instead. Apply the observer
+    # position; reject the whole record if the second segment cannot be
+    # applied.
     if len(line) >= 95 and line[94] in ("s", "v"):
         if not _apply_mpc80_second_line(line[80:160].ljust(80), obs):
             return None

--- a/digest2/src/digest2/observation.py
+++ b/digest2/src/digest2/observation.py
@@ -299,7 +299,10 @@ def parse_mpc80(line: str) -> Optional[Observation]:
     # position; reject the whole record if the second segment cannot be
     # applied.
     if len(line) >= 95 and line[94] in ("s", "v"):
-        if not _apply_mpc80_second_line(line[80:160].ljust(80), obs):
+        second = line[80:160].ljust(80)
+        if second[0:12] != line[0:12]:
+            return None
+        if not _apply_mpc80_second_line(second, obs):
             return None
 
     return obs

--- a/digest2/tests/test_satellite.py
+++ b/digest2/tests/test_satellite.py
@@ -18,6 +18,7 @@ from digest2.observation import (
     Observation,
     parse_ades_psv,
     parse_ades_xml,
+    parse_mpc80,
     parse_mpc80_file,
 )
 
@@ -284,6 +285,106 @@ class TestMpc80SecondLine:
         assert obs.spacebased is True
         expected = [v * _KM_TO_AU for v in _roving_position(0.5, 0.7, 2000.0)]
         assert obs.earth_obs == expected
+
+
+class TestMpc80DbRecords:
+    """160-column database records: the MPC ``obs`` table stores satellite /
+    roving observations as first line + second line concatenated in one
+    ``obs80`` value. parse_mpc80 must apply the second segment's observer
+    position (the digest2-service /digest2_trkid path feeds these records
+    one at a time, so parse_mpc80_file's pairing never runs)."""
+
+    @staticmethod
+    def _db_record(index=0, code="C57", flag="1"):
+        ground = MPC80_GROUND_LINES[index]
+        x, y, z = MPC80_SAT_POSITIONS[index]
+        sat_line = ground[:14] + "S" + ground[15:77] + code
+        second = _sat_second_line(sat_line, x, y, z, code=code, flag=flag)
+        return sat_line + second, (x, y, z)
+
+    def test_db_record_satellite_km(self):
+        record, (x, y, z) = self._db_record()
+        assert len(record) == 160
+        obs = parse_mpc80(record)
+        assert obs is not None
+        assert obs.spacebased is True
+        assert obs.earth_obs == [x * _KM_TO_AU, y * _KM_TO_AU, z * _KM_TO_AU]
+
+    def test_db_record_au_flag_not_scaled(self):
+        ground = MPC80_GROUND_LINES[0]
+        sat_line = ground[:14] + "S" + ground[15:77] + "C57"
+        second = _sat_second_line(sat_line, 0.01, -0.005, 0.002, flag="2")
+        obs = parse_mpc80(sat_line + second)
+        assert obs is not None
+        assert obs.spacebased is True
+        assert obs.earth_obs == [0.01, -0.005, 0.002]
+
+    def test_db_record_roving(self):
+        ground = MPC80_GROUND_LINES[0]
+        second = _sat_second_line(ground, 0.5, 0.7, 2000.0, note2="v",
+                                  code="247")
+        obs = parse_mpc80(ground + second)
+        assert obs is not None
+        assert obs.spacebased is True
+        expected = [v * _KM_TO_AU for v in _roving_position(0.5, 0.7, 2000.0)]
+        assert obs.earth_obs == expected
+
+    def test_plain_80_column_lines_unchanged(self):
+        # Ordinary ground-based line.
+        obs = parse_mpc80(MPC80_GROUND_LINES[0])
+        assert obs is not None
+        assert obs.spacebased is False
+        # A bare satellite first line (no second segment) keeps the previous
+        # behaviour: parsed, geocentric.
+        ground = MPC80_GROUND_LINES[0]
+        sat_line = ground[:14] + "S" + ground[15:77] + "C57"
+        obs = parse_mpc80(sat_line)
+        assert obs is not None
+        assert obs.spacebased is False
+
+    def test_padded_line_not_treated_as_record(self):
+        # Whitespace padding beyond column 80 must not change parsing
+        # (regression guard: only an 's'/'v' note2 at column 95 marks a
+        # two-line record).
+        for padded_len in (95, 120, 160):
+            obs = parse_mpc80(MPC80_GROUND_LINES[0].ljust(padded_len))
+            assert obs is not None
+            assert obs.spacebased is False
+            assert obs.earth_obs == [0.0, 0.0, 0.0]
+
+    def test_malformed_second_segment_rejects_record(self):
+        # Obscode mismatch between the two segments: reject the record
+        # rather than silently scoring geocentrically.
+        ground = MPC80_GROUND_LINES[0]
+        sat_line = ground[:14] + "S" + ground[15:77] + "C57"
+        second = _sat_second_line(sat_line, 235000.0, -180000.0, 95000.0,
+                                  code="C51")
+        assert parse_mpc80(sat_line + second) is None
+        # Garbage position fields: likewise rejected.
+        chars = list(_sat_second_line(sat_line, 0.0, 0.0, 0.0))
+        chars[34:45] = "not-a-float"
+        assert parse_mpc80(sat_line + "".join(chars)) is None
+
+    def test_db_record_scores_match_file_parse(self, tmp_path, model_path,
+                                               obscodes_path,
+                                               empty_config_path):
+        """classify_tracklet on 160-column DB records must score identically
+        to classify_file on the equivalent two-line file."""
+        records = []
+        for i in range(len(MPC80_GROUND_LINES)):
+            record, _ = self._db_record(index=i)
+            records.append(record)
+        file_path = _write_sat_obs80(tmp_path / "sat.obs")
+
+        with Digest2(model_path=model_path, obscodes_path=obscodes_path,
+                     config_path=empty_config_path, repeatable=True) as d2:
+            obs_list = [parse_mpc80(r) for r in records]
+            assert all(o is not None and o.spacebased for o in obs_list)
+            r_records = d2.classify_tracklet(obs_list)
+            r_file = d2.classify_file(file_path)[0]
+
+        assert r_records.raw.NEO == r_file.raw.NEO
+        assert r_records.noid.NEO == r_file.noid.NEO
 
 
 class TestObservationToTuple:

--- a/digest2/tests/test_satellite.py
+++ b/digest2/tests/test_satellite.py
@@ -370,6 +370,24 @@ class TestMpc80DbRecords:
         chars[34:45] = "not-a-float"
         assert parse_mpc80(sat_line + "".join(chars)) is None
 
+    def test_designation_mismatch_rejects_record(self):
+        # The two segments of a 160-column record must carry the SAME
+        # designation in columns [0:12] — a mismatch means the segments
+        # belong to different observations (a malformed/mis-joined DB
+        # record), so the whole record is rejected rather than attaching
+        # the wrong observer position.
+        ground = MPC80_GROUND_LINES[0]
+        sat_line = ground[:14] + "S" + ground[15:77] + "C57"
+        second = _sat_second_line(sat_line, 235000.0, -180000.0, 95000.0)
+        # Sanity: with matching designations the record parses space-based.
+        good = parse_mpc80(sat_line + second)
+        assert good is not None and good.spacebased is True
+        # Now corrupt the second segment's designation field only.
+        mismatched = list(second)
+        mismatched[0:12] = "     K16S99X".ljust(12)
+        assert second[0:12] != "".join(mismatched[0:12])
+        assert parse_mpc80(sat_line + "".join(mismatched)) is None
+
     def test_db_record_scores_match_file_parse(self, tmp_path, model_path,
                                                obscodes_path,
                                                empty_config_path):

--- a/digest2/tests/test_satellite.py
+++ b/digest2/tests/test_satellite.py
@@ -288,11 +288,16 @@ class TestMpc80SecondLine:
 
 
 class TestMpc80DbRecords:
-    """160-column database records: the MPC ``obs`` table stores satellite /
-    roving observations as first line + second line concatenated in one
-    ``obs80`` value. parse_mpc80 must apply the second segment's observer
-    position (the digest2-service /digest2_trkid path feeds these records
-    one at a time, so parse_mpc80_file's pairing never runs)."""
+    """Convenience handling of 160-column concatenated records.
+
+    The standard sequential two-line form (observation line + separate
+    's'/'v' position line) is already handled by parse_mpc80_file — see
+    TestMpc80SecondLine above; nothing requires callers to concatenate.
+    But the MPC ``obs`` table happens to store both lines concatenated in
+    one ``obs80`` value, and per-record consumers (e.g. digest2-service's
+    /digest2_trkid) feed those records to parse_mpc80 one at a time, where
+    the file-level pairing never runs — so parse_mpc80 applies the second
+    segment itself."""
 
     @staticmethod
     def _db_record(index=0, code="C57", flag="1"):


### PR DESCRIPTION
### Summary

Completes the space-based-observer work of #70 for the remaining entry point.

The MPC `obs` table stores a satellite/roving observation as one **160-column `obs80` value** — the observation line and its `'s'`/`'v'` second line concatenated. Per-record database consumers (notably **digest2-service's `/digest2_trkid`** in mpc-software, and **mpc-heliolinc's** scoring fallback) feed these records to `parse_mpc80` one at a time, so `parse_mpc80_file`'s second-line pairing never runs — and space-based observations were still silently scored **from the geocenter**, the same bug class #70 fixed for the ADES XML/PSV and file paths.

**Scope note:** the standard sequential two-line form (observation line followed by a separate `'s'`/`'v'` position line) is *already fully handled* by `parse_mpc80_file()` since #70, and remains the normal way to supply satellite observations — nothing here changes that, and callers are **not** required to use the concatenated form. This PR adds the 160-column concatenated variant purely as a convenience, because that is the packaging the MPC database happens to deliver to per-record consumers.

### Change

- `parse_mpc80` detects a second segment (note2 `'s'`/`'v'` at column 95) and applies its observer position via the existing `_apply_mpc80_second_line`.
- A malformed second segment (bad position fields, obscode mismatch) rejects the whole record (returns `None`) rather than silently degrading to a geocentric observer.
- Back-compat preserved: plain 80-column lines, bare satellite first lines, and whitespace-padded over-length lines parse exactly as before (regression-tested).
- Version 2.8.1 → 2.8.2; README note under Input Formats.

### Tests

7 new cases in `tests/test_satellite.py` (`TestMpc80DbRecords`), including a score-level assertion that `classify_tracklet` on 160-column records produces **identical** raw/noid NEO scores to `classify_file` on the equivalent two-line file. 