### PR TITLE
wis: add PyPI release workflow (trusted publishing)

### DIFF
--- a/.github/workflows/wis-python-release.yml
+++ b/.github/workflows/wis-python-release.yml
@@ -1,0 +1,80 @@
+name: wis-python-release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  # Only run for wis releases (tags starting with "wis-v")
+  check-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      is_wis: ${{ steps.check.outputs.is_wis }}
+    steps:
+      - name: Check release tag
+        id: check
+        run: |
+          if [[ "${{ github.event.release.tag_name }}" == wis-v* ]]; then
+            echo "is_wis=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_wis=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # wis is pure Python: one sdist + one universal wheel is all we need
+  # (no compiled extensions, so no cibuildwheel matrix like digest2's).
+  build:
+    needs: check-tag
+    if: needs.check-tag.outputs.is_wis == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check tag matches package version
+        run: |
+          tag_version="${GITHUB_REF_NAME#wis-v}"
+          pkg_version="$(python -c "import tomllib; print(tomllib.load(open('wis/pyproject.toml','rb'))['project']['version'])")"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "Release tag wis-v$tag_version does not match wis/pyproject.toml version $pkg_version" >&2
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: |
+          cd wis
+          pip install build
+          python -m build
+
+      - name: Check artifacts
+        run: |
+          pip install twine
+          python -m twine check wis/dist/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wis-dist
+          path: wis/dist/*
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/wis/README.md
+++ b/wis/README.md
@@ -296,3 +296,23 @@ Tests include unit tests for individual modules and integration tests that verif
 * Better caching (currently a local cache for entire call signatures; could be remote-friendly, as well as individual times)
 * Add more unit tests
 * Provide a Docker image with pre‑downloaded kernels
+
+
+## Releasing to PyPI
+
+Publication is automated via GitHub Actions and PyPI [trusted
+publishing](https://docs.pypi.org/trusted-publishers/) (no tokens), mirroring
+the `digest2` release flow in this repository.
+
+**To release a new version:**
+
+1. Update `version` in `wis/pyproject.toml` and merge that change to `main`.
+2. On the repository's [Releases page](https://github.com/Smithsonian/mpc-public/releases),
+   create a new release:
+   - **Tag:** `wis-v<version>` (must start with `wis-v` and match the
+     `pyproject.toml` version — the workflow verifies this and fails on mismatch)
+   - **Target:** `main`
+   - **Title/notes:** describe what changed.
+3. Publishing the release triggers `wis-python-release.yml`, which builds the
+   sdist + wheel, runs `twine check`, and uploads to
+   [PyPI](https://pypi.org/project/wis/).


### PR DESCRIPTION
Follow-up to #71, where Benasked for wis to be published to PyPI.

This adds `wis-python-release.yml`, mirroring the `digest2` release flow already in this repo:

- Triggered by publishing a GitHub Release tagged `wis-v<version>` (targeting `main`).
- Verifies the tag matches `wis/pyproject.toml`'s version, builds the sdist + universal wheel (wis is pure Python — no cibuildwheel matrix needed), `twine check`s them, and publishes to PyPI via **trusted publishing** (environment `pypi`; the trusted-publisher entry for this repo/workflow is already configured on the PyPI `wis` project — no tokens anywhere).
- README gains the release procedure, in the same style as digest2's.

Once merged, publishing v2.0.0 is one step: create release `wis-v2.0.0` targeting `main`.


