### PR TITLE
docs: Pointings and Negative Observations API tutorials

### DIFF
--- a/docs-public/docs/tutorials/api_tutorials.md
+++ b/docs-public/docs/tutorials/api_tutorials.md
@@ -17,3 +17,11 @@ Tutorials on how to use various of the MPC's APIs are linked below.
  - [WAMO API](notebooks/mpc_tutorial_api_wamo.ipynb)
  - [List API](notebooks/mpc_tutorial_api_lists.ipynb)
  - [Magnitude Band API](notebooks/mpc_tutorial_api_mag_band.ipynb)
+ - [Pointings API](notebooks/mpc_tutorial_api_pointings.ipynb)
+ - [Negative Observations API](notebooks/mpc_tutorial_api_negative_observations.ipynb)
+
+<!-- TODO: the endpoint at https://data.minorplanetcenter.net/whatsup (linked from the
+     data.minorplanetcenter.net navigation, currently returns 403 to anonymous requests)
+     has neither API documentation nor a tutorial. Revisit whether it is intended to be
+     public, and if so add both. Noted 2026-09-03. -->
+

--- a/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_negative_observations.ipynb
+++ b/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_negative_observations.ipynb
@@ -1,0 +1,421 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "negobs-00",
+   "metadata": {},
+   "source": [
+    "# MPC Negative Observations API\n",
+    "\n",
+    "#### This tutorial demonstrates how to report a *negative observation* — \"we imaged this field and did **not** detect the object\" — to the Minor Planet Center.\n",
+    "\n",
+    "Negative observations are valuable science: knowing that a known or suspected object was *not* seen down to a stated limiting magnitude helps constrain orbits (especially for NEOCP candidates), rule out identifications, and calibrate survey performance. See the [negative observations documentation](https://docs.minorplanetcenter.net/mpc-ops-docs/observations/negative-observations/) for the scientific background.\n",
+    "\n",
+    "A negative observation is submitted as a **pointing record with extra fields**: the payload describes the exposure exactly as in the [Pointings API tutorial](mpc_tutorial_api_pointings.ipynb), and adds fields stating which object was looked for, that it was not found, and (optionally) details of how the limiting magnitude was estimated.\n",
+    "\n",
+    "Further information and documentation can be found at:\n",
+    " - [Pointing submissions documentation](https://docs.minorplanetcenter.net/services/negative_observations/) (field definitions for pointings and negative observations)\n",
+    " - [Negative observations documentation](https://docs.minorplanetcenter.net/mpc-ops-docs/observations/negative-observations/)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-01",
+   "metadata": {},
+   "source": [
+    "# Import Packages\n",
+    "Here we import the standard python packages we use in this tutorial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "negobs-02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T00:48:12.753045Z",
+     "iopub.status.busy": "2026-09-04T00:48:12.752884Z",
+     "iopub.status.idle": "2026-09-04T00:48:12.802524Z",
+     "shell.execute_reply": "2026-09-04T00:48:12.802050Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-03",
+   "metadata": {},
+   "source": [
+    "# API Parameters\n",
+    "\n",
+    "A negative observation is submitted as a JSON payload via a POST request using `requests.post(url, json=payload)`.\n",
+    "\n",
+    "## Pointing fields\n",
+    "\n",
+    "The payload contains all of the usual pointing fields — see the [Pointings API tutorial](mpc_tutorial_api_pointings.ipynb) for the full tables:\n",
+    "\n",
+    "- **Required:** `action` (`\"exposed\"`), `surveyExpName`, `mode`, `mpcCode`, `time`, `duration`, `center`, `limit`\n",
+    "- **Field geometry (exactly one):** `width`, `widths`, `fieldDiam`, or `offsets`\n",
+    "- **Optional:** `filter`, `nonsidereal`\n",
+    "\n",
+    "## Additional required fields for negative observations\n",
+    "\n",
+    "| Field | Type | Description |\n",
+    "|-------|------|-------------|\n",
+    "| `found` | Boolean | `false` for a negative observation |\n",
+    "| `desig` | String | Designation of the object searched for, in [packed format](https://docs.minorplanetcenter.net/mpc-ops-docs/designations/packed-designations/), or a `trksub` for an NEOCP candidate |\n",
+    "| `submitter` | String | Name of the submitter |\n",
+    "\n",
+    "## Additional optional fields\n",
+    "\n",
+    "| Field | Description |\n",
+    "|-------|-------------|\n",
+    "| `limiting_mag_method` | Integer in {1, 2, 3, 4} identifying how the limiting magnitude was estimated (see below) |\n",
+    "| `notes` | Free-text notes |\n",
+    "| `number_of_stars_fov` | Number of stars in the field of view |\n",
+    "| `pixel_scale` | Pixel scale of the detector |\n",
+    "| `seeing` | Seeing estimate |\n",
+    "| `software` | Software used |\n",
+    "| `stacked` | Whether frames were stacked |\n",
+    "| `fill_factor` | Fraction of the field of view covered by active detector area |\n",
+    "\n",
+    "## Limiting magnitude methods\n",
+    "\n",
+    "1. On a star stack, measure faint objects at the limit and scale to 5-sigma.\n",
+    "2. On a stack, measure the sky noise, scale for a point-source area, and then to 5-sigma.\n",
+    "3. Insert artificial objects into the frames and measure the 50 percent detection efficiency.\n",
+    "4. Manual/custom method.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-04",
+   "metadata": {},
+   "source": [
+    "# API Endpoint\n",
+    "\n",
+    "<span style=\"color: red;\">**Warning:** The Negative Observations API has no test endpoint. Every POST request inserts a real record into the MPC Pointings Database. Do not submit example data.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "negobs-05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T00:48:12.804167Z",
+     "iopub.status.busy": "2026-09-04T00:48:12.804067Z",
+     "iopub.status.idle": "2026-09-04T00:48:12.805785Z",
+     "shell.execute_reply": "2026-09-04T00:48:12.805470Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# URL of the Negative Observations API endpoint\n",
+    "url = \"https://www.minorplanetcenter.net/cgi-bin/pointings/submit_negativeObs\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-06",
+   "metadata": {},
+   "source": [
+    "# Example 1: Negative Observation of an NEOCP Candidate\n",
+    "\n",
+    "This example reports a targeted follow-up exposure in which an NEOCP candidate (identified by its `trksub`, here `\"P11Uypl\"`) was searched for but **not found** down to a limiting magnitude of 22.7.\n",
+    "\n",
+    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code below is displayed as markdown rather than an executable code cell.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "negobs-07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T00:48:12.807243Z",
+     "iopub.status.busy": "2026-09-04T00:48:12.807164Z",
+     "iopub.status.idle": "2026-09-04T00:48:12.809473Z",
+     "shell.execute_reply": "2026-09-04T00:48:12.809055Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"action\": \"exposed\",\n",
+      "  \"surveyExpName\": \"20180101-EX0132\",\n",
+      "  \"mode\": \"target\",\n",
+      "  \"mpcCode\": \"I52\",\n",
+      "  \"time\": \"2024-03-03T12:20:33.46\",\n",
+      "  \"duration\": 45,\n",
+      "  \"center\": [\n",
+      "    255.167,\n",
+      "    -29.008\n",
+      "  ],\n",
+      "  \"widths\": [\n",
+      "    0.82,\n",
+      "    0.64\n",
+      "  ],\n",
+      "  \"desig\": \"P11Uypl\",\n",
+      "  \"limit\": 22.7,\n",
+      "  \"nonsidereal\": true,\n",
+      "  \"filter\": \"V\",\n",
+      "  \"found\": false,\n",
+      "  \"submitter\": \"A. Tomatic\",\n",
+      "  \"fill_factor\": 0.98\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build the JSON payload for a negative observation of an NEOCP candidate\n",
+    "payload_negative = {\n",
+    "    \"action\": \"exposed\",\n",
+    "    \"surveyExpName\": \"20180101-EX0132\",\n",
+    "    \"mode\": \"target\",\n",
+    "    \"mpcCode\": \"I52\",\n",
+    "    \"time\": \"2024-03-03T12:20:33.46\",\n",
+    "    \"duration\": 45,\n",
+    "    \"center\": [255.167, -29.008],\n",
+    "    \"widths\": [0.82, 0.64],\n",
+    "    \"desig\": \"P11Uypl\",\n",
+    "    \"limit\": 22.7,\n",
+    "    \"nonsidereal\": True,\n",
+    "    \"filter\": \"V\",\n",
+    "    \"found\": False,\n",
+    "    \"submitter\": \"A. Tomatic\",\n",
+    "    \"fill_factor\": 0.98\n",
+    "}\n",
+    "\n",
+    "# Display the JSON payload\n",
+    "print(json.dumps(payload_negative, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-08",
+   "metadata": {},
+   "source": [
+    "Submit this negative observation to the API:\n",
+    "\n",
+    "<span style=\"color: red;\">This cell is deliberately set to markdown format (rather than code) to prevent accidental submission of example data into the MPC's production database.</span>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-09",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "\"\"\"\n",
+    "This cell deliberately set to `markdown` format (rather than `code`) to reduce the risk of\n",
+    "accidental submission of example data into the MPC's production system.\n",
+    "\"\"\"\n",
+    "\n",
+    "# Submit the negative observation\n",
+    "response = requests.post(url, json=payload_negative)\n",
+    "\n",
+    "# Print the response\n",
+    "print(response.status_code)\n",
+    "print(response.reason)\n",
+    "print(response.text)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-10",
+   "metadata": {},
+   "source": [
+    "# Example 2: Negative Observation with Detection-Efficiency Metadata\n",
+    "\n",
+    "This example reports a negative observation of a designated object (packed designation `\"K18A00A\"`) and includes the optional metadata fields describing how the limiting magnitude was estimated — here method 3 (artificial objects inserted into the frames, 50 percent detection efficiency) — along with the observing conditions and software used.\n",
+    "\n",
+    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code below is displayed as markdown rather than an executable code cell.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "negobs-11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T00:48:12.810802Z",
+     "iopub.status.busy": "2026-09-04T00:48:12.810728Z",
+     "iopub.status.idle": "2026-09-04T00:48:12.812941Z",
+     "shell.execute_reply": "2026-09-04T00:48:12.812634Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"action\": \"exposed\",\n",
+      "  \"surveyExpName\": \"20240303-EX0201\",\n",
+      "  \"mode\": \"target\",\n",
+      "  \"mpcCode\": \"I52\",\n",
+      "  \"time\": \"2024-03-03T13:05:10.12\",\n",
+      "  \"duration\": 120,\n",
+      "  \"center\": [\n",
+      "    141.502,\n",
+      "    12.337\n",
+      "  ],\n",
+      "  \"fieldDiam\": 1.1,\n",
+      "  \"desig\": \"K18A00A\",\n",
+      "  \"limit\": 23.1,\n",
+      "  \"filter\": \"r\",\n",
+      "  \"found\": false,\n",
+      "  \"submitter\": \"A. Tomatic\",\n",
+      "  \"limiting_mag_method\": 3,\n",
+      "  \"seeing\": 1.4,\n",
+      "  \"pixel_scale\": 0.47,\n",
+      "  \"number_of_stars_fov\": 1450,\n",
+      "  \"software\": \"custom-pipeline\",\n",
+      "  \"stacked\": true,\n",
+      "  \"fill_factor\": 0.95,\n",
+      "  \"notes\": \"Three 40s frames stacked on the predicted motion; no candidate at the ephemeris position.\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build the JSON payload with optional limiting-magnitude metadata\n",
+    "payload_negative_meta = {\n",
+    "    \"action\": \"exposed\",\n",
+    "    \"surveyExpName\": \"20240303-EX0201\",\n",
+    "    \"mode\": \"target\",\n",
+    "    \"mpcCode\": \"I52\",\n",
+    "    \"time\": \"2024-03-03T13:05:10.12\",\n",
+    "    \"duration\": 120,\n",
+    "    \"center\": [141.502, 12.337],\n",
+    "    \"fieldDiam\": 1.1,\n",
+    "    \"desig\": \"K18A00A\",\n",
+    "    \"limit\": 23.1,\n",
+    "    \"filter\": \"r\",\n",
+    "    \"found\": False,\n",
+    "    \"submitter\": \"A. Tomatic\",\n",
+    "    \"limiting_mag_method\": 3,\n",
+    "    \"seeing\": 1.4,\n",
+    "    \"pixel_scale\": 0.47,\n",
+    "    \"number_of_stars_fov\": 1450,\n",
+    "    \"software\": \"custom-pipeline\",\n",
+    "    \"stacked\": True,\n",
+    "    \"fill_factor\": 0.95,\n",
+    "    \"notes\": \"Three 40s frames stacked on the predicted motion; no candidate at the ephemeris position.\"\n",
+    "}\n",
+    "\n",
+    "# Display the JSON payload\n",
+    "print(json.dumps(payload_negative_meta, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-12",
+   "metadata": {},
+   "source": [
+    "Submit this negative observation to the API:\n",
+    "\n",
+    "<span style=\"color: red;\">This cell is deliberately set to markdown format (rather than code) to prevent accidental submission of example data into the MPC's production database.</span>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-13",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "\"\"\"\n",
+    "This cell deliberately set to `markdown` format (rather than `code`) to reduce the risk of\n",
+    "accidental submission of example data into the MPC's production system.\n",
+    "\"\"\"\n",
+    "\n",
+    "# Submit the negative observation\n",
+    "response = requests.post(url, json=payload_negative_meta)\n",
+    "\n",
+    "# Print the response\n",
+    "print(response.status_code)\n",
+    "print(response.reason)\n",
+    "print(response.text)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-14",
+   "metadata": {},
+   "source": [
+    "# Notes on Responses and Common Errors\n",
+    "\n",
+    "A successful submission returns a JSON response with the inserted record ID, in the same style as the Pointings API.\n",
+    "\n",
+    "Common reasons for failed submissions include:\n",
+    "\n",
+    "- Missing the negative-observation fields (`found`, `desig`, `submitter`)\n",
+    "- Missing required pointing fields (e.g. `surveyExpName`, `mpcCode`, `time`, `duration`, `center`, `limit`)\n",
+    "- No field geometry specified, or multiple geometry fields provided (must be exactly one of `width`, `widths`, `fieldDiam`, `offsets`)\n",
+    "- Invalid `time` format (must be `YYYY-MM-DDThh:mm:ss.sss`)\n",
+    "- Spaces in `surveyExpName`\n",
+    "- `desig` not in packed format (or not a valid NEOCP `trksub`)\n",
+    "\n",
+    "You can also submit negative observations using cURL:\n",
+    "\n",
+    "```bash\n",
+    "curl -X POST -H \"Content-Type: application/json\" \\\n",
+    "  -d @json.txt https://www.minorplanetcenter.net/cgi-bin/pointings/submit_negativeObs\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "negobs-15",
+   "metadata": {},
+   "source": [
+    "# Summary\n",
+    "\n",
+    "This tutorial demonstrated how to use the MPC Negative Observations API to report that an object was searched for but not detected.\n",
+    "\n",
+    "- **API endpoint**: `https://www.minorplanetcenter.net/cgi-bin/pointings/submit_negativeObs`\n",
+    "- **Method**: `requests.post(url, json=payload)`\n",
+    "- **Payload**: a standard pointing record (see the [Pointings API tutorial](mpc_tutorial_api_pointings.ipynb)) plus `found: false`, the `desig` searched for (packed format, or a `trksub` for NEOCP candidates), and the `submitter` name\n",
+    "- **Optional metadata**: `limiting_mag_method` (1-4), `seeing`, `pixel_scale`, `number_of_stars_fov`, `software`, `stacked`, `fill_factor`, `notes`\n",
+    "\n",
+    "For more information, see:\n",
+    " - [Pointing submissions documentation](https://docs.minorplanetcenter.net/services/negative_observations/)\n",
+    " - [Negative observations documentation](https://docs.minorplanetcenter.net/mpc-ops-docs/observations/negative-observations/)\n",
+    " - [Pointings API tutorial](mpc_tutorial_api_pointings.ipynb)\n",
+    "\n",
+    "For questions or feedback, contact the MPC via the [Jira Helpdesk](https://mpc-service.atlassian.net/servicedesk/customer/portal/13/create/148)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_negative_observations.ipynb
+++ b/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_negative_observations.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# MPC Negative Observations API\n",
     "\n",
-    "#### This tutorial demonstrates how to report a *negative observation* — \"we imaged this field and did **not** detect the object\" — to the Minor Planet Center.\n",
+    "#### This tutorial demonstrates how to report a *negative observation*, i.e. \"We imaged this field and did **not** detect the object\", to the Minor Planet Center.\n",
     "\n",
     "Negative observations are valuable science: knowing that a known or suspected object was *not* seen down to a stated limiting magnitude helps constrain orbits (especially for NEOCP candidates), rule out identifications, and calibrate survey performance. See the [negative observations documentation](https://docs.minorplanetcenter.net/mpc-ops-docs/observations/negative-observations/) for the scientific background.\n",
     "\n",
@@ -29,16 +29,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "negobs-02",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-04T00:48:12.753045Z",
-     "iopub.status.busy": "2026-09-04T00:48:12.752884Z",
-     "iopub.status.idle": "2026-09-04T00:48:12.802524Z",
-     "shell.execute_reply": "2026-09-04T00:48:12.802050Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import requests\n",
@@ -103,16 +96,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "negobs-05",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-04T00:48:12.804167Z",
-     "iopub.status.busy": "2026-09-04T00:48:12.804067Z",
-     "iopub.status.idle": "2026-09-04T00:48:12.805785Z",
-     "shell.execute_reply": "2026-09-04T00:48:12.805470Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# URL of the Negative Observations API endpoint\n",
@@ -128,21 +114,14 @@
     "\n",
     "This example reports a targeted follow-up exposure in which an NEOCP candidate (identified by its `trksub`, here `\"P11Uypl\"`) was searched for but **not found** down to a limiting magnitude of 22.7.\n",
     "\n",
-    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code below is displayed as markdown rather than an executable code cell.</span>"
+    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code a couple of cells below is displayed as markdown rather than an executable code cell.</span>"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "negobs-07",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-09-04T00:48:12.807243Z",
-     "iopub.status.busy": "2026-09-04T00:48:12.807164Z",
-     "iopub.status.idle": "2026-09-04T00:48:12.809473Z",
-     "shell.execute_reply": "2026-09-04T00:48:12.809055Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -238,7 +217,7 @@
     "\n",
     "This example reports a negative observation of a designated object (packed designation `\"K18A00A\"`) and includes the optional metadata fields describing how the limiting magnitude was estimated — here method 3 (artificial objects inserted into the frames, 50 percent detection efficiency) — along with the observing conditions and software used.\n",
     "\n",
-    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code below is displayed as markdown rather than an executable code cell.</span>"
+    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code a couple of cells below is displayed as markdown rather than an executable code cell.</span>"
    ]
   },
   {

--- a/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_negative_observations.ipynb
+++ b/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_negative_observations.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# MPC Negative Observations API\n",
     "\n",
-    "#### This tutorial demonstrates how to report a *negative observation*, i.e. \"We imaged this field and did **not** detect the object\", to the Minor Planet Center.\n",
+    "#### This tutorial demonstrates the procedure for reporting a *negative observation* to the Minor Planet Center. i.e. \"We imaged this field and did **not** detect an object that was expected to be there\".\n",
     "\n",
     "Negative observations are valuable science: knowing that a known or suspected object was *not* seen down to a stated limiting magnitude helps constrain orbits (especially for NEOCP candidates), rule out identifications, and calibrate survey performance. See the [negative observations documentation](https://docs.minorplanetcenter.net/mpc-ops-docs/observations/negative-observations/) for the scientific background.\n",
     "\n",

--- a/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_negative_observations.ipynb
+++ b/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_negative_observations.ipynb
@@ -4,19 +4,7 @@
    "cell_type": "markdown",
    "id": "negobs-00",
    "metadata": {},
-   "source": [
-    "# MPC Negative Observations API\n",
-    "\n",
-    "#### This tutorial demonstrates the procedure for reporting a *negative observation* to the Minor Planet Center. i.e. \"We imaged this field and did **not** detect an object that was expected to be there\".\n",
-    "\n",
-    "Negative observations are valuable science: knowing that a known or suspected object was *not* seen down to a stated limiting magnitude helps constrain orbits (especially for NEOCP candidates), rule out identifications, and calibrate survey performance. See the [negative observations documentation](https://docs.minorplanetcenter.net/mpc-ops-docs/observations/negative-observations/) for the scientific background.\n",
-    "\n",
-    "A negative observation is submitted as a **pointing record with extra fields**: the payload describes the exposure exactly as in the [Pointings API tutorial](mpc_tutorial_api_pointings.ipynb), and adds fields stating which object was looked for, that it was not found, and (optionally) details of how the limiting magnitude was estimated.\n",
-    "\n",
-    "Further information and documentation can be found at:\n",
-    " - [Pointing submissions documentation](https://docs.minorplanetcenter.net/services/negative_observations/) (field definitions for pointings and negative observations)\n",
-    " - [Negative observations documentation](https://docs.minorplanetcenter.net/mpc-ops-docs/observations/negative-observations/)\n"
-   ]
+   "source": "# MPC Negative Observations API\n\n#### This tutorial demonstrates the procedure for reporting a *negative observation* to the Minor Planet Center. i.e. \"We imaged this field and did **not** detect an object that was expected to be there\".\n\nNegative observations are valuable to the MPC: knowing that a known or suspected object was *not* seen down to a stated limiting magnitude helps constrain orbits (especially for [NEOCP](https://docs.minorplanetcenter.net/mpc-ops-docs/data-and-services/neocp-notes/) candidates), rule out identifications, and calibrate survey performance. See the [negative observations documentation](https://docs.minorplanetcenter.net/mpc-ops-docs/observations/negative-observations/) for more scientific background.\n\nA negative observation is submitted as a **pointing record with extra fields**: the payload describes the exposure exactly as in the [Pointings API tutorial](mpc_tutorial_api_pointings.ipynb), and adds fields stating which object was looked for, that it was not found, and (optionally) details of how the limiting magnitude was estimated.\n\nFurther information and documentation can be found at:\n - [Pointings API tutorial](mpc_tutorial_api_pointings.ipynb) (the companion tutorial for standard pointing submissions)\n - [Pointing submissions documentation](https://docs.minorplanetcenter.net/services/negative_observations/) (field definitions for pointings and negative observations)\n - [Negative observations documentation](https://docs.minorplanetcenter.net/mpc-ops-docs/observations/negative-observations/)\n"
   },
   {
    "cell_type": "markdown",
@@ -331,27 +319,7 @@
    "cell_type": "markdown",
    "id": "negobs-14",
    "metadata": {},
-   "source": [
-    "# Notes on Responses and Common Errors\n",
-    "\n",
-    "A successful submission returns a JSON response with the inserted record ID, in the same style as the Pointings API.\n",
-    "\n",
-    "Common reasons for failed submissions include:\n",
-    "\n",
-    "- Missing the negative-observation fields (`found`, `desig`, `submitter`)\n",
-    "- Missing required pointing fields (e.g. `surveyExpName`, `mpcCode`, `time`, `duration`, `center`, `limit`)\n",
-    "- No field geometry specified, or multiple geometry fields provided (must be exactly one of `width`, `widths`, `fieldDiam`, `offsets`)\n",
-    "- Invalid `time` format (must be `YYYY-MM-DDThh:mm:ss.sss`)\n",
-    "- Spaces in `surveyExpName`\n",
-    "- `desig` not in packed format (or not a valid NEOCP `trksub`)\n",
-    "\n",
-    "You can also submit negative observations using cURL:\n",
-    "\n",
-    "```bash\n",
-    "curl -X POST -H \"Content-Type: application/json\" \\\n",
-    "  -d @json.txt https://www.minorplanetcenter.net/cgi-bin/pointings/submit_negativeObs\n",
-    "```"
-   ]
+   "source": "# Notes on Responses and Common Errors\n\nA successful submission returns a JSON response with the inserted record ID, in the same style as the Pointings API.\n\nCommon reasons for failed submissions include:\n\n- Missing the negative-observation fields (`found`, `desig`, `submitter`)\n- Missing required pointing fields (e.g. `surveyExpName`, `mpcCode`, `time`, `duration`, `center`, `limit`)\n- No field geometry specified, or multiple geometry fields provided (must be exactly one of `width`, `widths`, `fieldDiam`, `offsets`)\n- Invalid `time` format (must be `YYYY-MM-DDThh:mm:ss.sss`)\n- Spaces in `surveyExpName`\n- `desig` not in packed format (or not a valid NEOCP `trksub`)\n\nYou can also submit negative observations using cURL:\n\n```bash\ncurl -X POST -H \"Content-Type: application/json\" \\\n  -d @payload.json https://www.minorplanetcenter.net/cgi-bin/pointings/submit_negativeObs\n```"
   },
   {
    "cell_type": "markdown",

--- a/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_pointings.ipynb
+++ b/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_pointings.ipynb
@@ -134,7 +134,7 @@
     "\n",
     "This example demonstrates submitting a pointing for a square, equatorially-aligned survey field using the `width` parameter (side length in degrees).\n",
     "\n",
-    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code below is displayed as markdown rather than an executable code cell.</span>"
+    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code a couple of cells below is displayed as markdown rather than an executable code cell.</span>"
    ]
   },
   {

--- a/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_pointings.ipynb
+++ b/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_pointings.ipynb
@@ -1,0 +1,622 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "pointings-00",
+   "metadata": {},
+   "source": [
+    "# MPC Pointings API\n",
+    "\n",
+    "#### This tutorial demonstrates how to submit telescope pointing information to the Minor Planet Center using the Pointings API.\n",
+    "\n",
+    "The MPC Pointings Database collects details about telescope exposures — direction, timing, duration, and field geometry — relevant to the near-Earth object (NEO) community. The database facilitates:\n",
+    "\n",
+    "- Community coordination of NEO follow-up activities\n",
+    "- Internal MPC data processing\n",
+    "- Community pre-recovery efforts\n",
+    "\n",
+    "Two types of pointing information are collected:\n",
+    "\n",
+    "- **Exposed pointings** — recorded at or near the actual time of exposure\n",
+    "- **Queued pointings** — scheduled observations (future capability)\n",
+    "\n",
+    "In the examples below we use [python](https://en.wikipedia.org/wiki/Python_(programming_language)) code to demonstrate submission of pointings via the API.\n",
+    "\n",
+    "Further information and documentation concerning the Pointings API can be found at:\n",
+    " - [Pointing submissions documentation](https://docs.minorplanetcenter.net/services/negative_observations/)\n",
+    "\n",
+    "A companion tutorial covers the closely-related [Negative Observations submission API](mpc_tutorial_api_negative_observations.ipynb), which reports that a known or suspected object was *not* detected in an exposure."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-01",
+   "metadata": {},
+   "source": [
+    "# Import Packages\n",
+    "Here we import the standard python packages we use in this tutorial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "pointings-02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T00:48:11.836387Z",
+     "iopub.status.busy": "2026-09-04T00:48:11.836202Z",
+     "iopub.status.idle": "2026-09-04T00:48:12.014784Z",
+     "shell.execute_reply": "2026-09-04T00:48:12.014320Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-03",
+   "metadata": {},
+   "source": [
+    "# API Parameters\n",
+    "\n",
+    "Pointings are submitted as a JSON payload via a POST request using `requests.post(url, json=payload)`.\n",
+    "\n",
+    "## Required Fields\n",
+    "\n",
+    "| Field | Type | Description |\n",
+    "|-------|------|-------------|\n",
+    "| `action` | String | Must be `\"exposed\"`. Future versions will allow `\"queued\"`. |\n",
+    "| `surveyExpName` | String | Unique identifier for this exposure within the survey. Max 64 characters, no spaces. |\n",
+    "| `mode` | String | `\"survey\"` or `\"target\"` |\n",
+    "| `mpcCode` | String | MPC-assigned 3 or 4-character site code |\n",
+    "| `time` | String | UTC date and time of the beginning of the exposure: `YYYY-MM-DDThh:mm:ss.sss` |\n",
+    "| `duration` | Numeric | Length of the exposure in seconds |\n",
+    "| `center` | List | Right ascension and declination of the field center in decimal degrees (J2000 equinox). Use 4-8 decimal places for RA and Dec. |\n",
+    "| `limit` | Numeric | Faintest magnitude for which astrometric measurements can be made (typically five sigma) |\n",
+    "| `desig` | String | Target designation. Required when `mode` is `\"target\"`. |\n",
+    "\n",
+    "## Field Geometry\n",
+    "\n",
+    "Exactly **one** of the following fields must be provided to describe the field shape:\n",
+    "\n",
+    "| Field | Type | Description |\n",
+    "|-------|------|-------------|\n",
+    "| `width` | Numeric | Side length of a square, equatorially-aligned field (degrees) |\n",
+    "| `widths` | List | Side lengths `[RA, Dec]` of a rectangular, equatorially-aligned field (degrees) |\n",
+    "| `fieldDiam` | Numeric | Diameter of a circular field (degrees) |\n",
+    "| `offsets` | List | Tangent plane offsets (w.r.t. field center) of field corners as four `[RA, Dec]` ordered pairs (degrees) |\n",
+    "\n",
+    "## Optional Fields\n",
+    "\n",
+    "| Field | Type | Description |\n",
+    "|-------|------|-------------|\n",
+    "| `filter` | String | Short name for the bandpass. Use `\"UNFILTERED\"` if no filter was used. No spaces. |\n",
+    "| `nonsidereal` | Boolean | Set to `true` if the exposure was not tracked sidereally. Defaults to `false`. |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-04",
+   "metadata": {},
+   "source": [
+    "# API Endpoint\n",
+    "\n",
+    "<span style=\"color: red;\">**Warning:** The Pointings API has no test endpoint. Every POST request inserts a real record into the MPC Pointings Database. Do not submit example data.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "pointings-05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T00:48:12.016583Z",
+     "iopub.status.busy": "2026-09-04T00:48:12.016478Z",
+     "iopub.status.idle": "2026-09-04T00:48:12.018246Z",
+     "shell.execute_reply": "2026-09-04T00:48:12.017864Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# URL of the Pointings API endpoint\n",
+    "url = \"https://www.minorplanetcenter.net/cgi-bin/pointings/submit\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-06",
+   "metadata": {},
+   "source": [
+    "# Example 1: Square Survey Field (`width`)\n",
+    "\n",
+    "This example demonstrates submitting a pointing for a square, equatorially-aligned survey field using the `width` parameter (side length in degrees).\n",
+    "\n",
+    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code below is displayed as markdown rather than an executable code cell.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "pointings-07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T00:48:12.019470Z",
+     "iopub.status.busy": "2026-09-04T00:48:12.019393Z",
+     "iopub.status.idle": "2026-09-04T00:48:12.021618Z",
+     "shell.execute_reply": "2026-09-04T00:48:12.021265Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"action\": \"exposed\",\n",
+      "  \"surveyExpName\": \"AK101_Jxpf341-a\",\n",
+      "  \"mode\": \"survey\",\n",
+      "  \"mpcCode\": \"802\",\n",
+      "  \"time\": \"2018-01-01T11:22:33.4567\",\n",
+      "  \"duration\": 120,\n",
+      "  \"center\": [\n",
+      "    255.1667,\n",
+      "    -29.0079\n",
+      "  ],\n",
+      "  \"width\": 2.5,\n",
+      "  \"limit\": 19.5,\n",
+      "  \"filter\": \"r\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build the JSON payload for a square survey field\n",
+    "payload_square = {\n",
+    "    \"action\": \"exposed\",\n",
+    "    \"surveyExpName\": \"AK101_Jxpf341-a\",\n",
+    "    \"mode\": \"survey\",\n",
+    "    \"mpcCode\": \"802\",\n",
+    "    \"time\": \"2018-01-01T11:22:33.4567\",\n",
+    "    \"duration\": 120,\n",
+    "    \"center\": [255.1667, -29.0079],\n",
+    "    \"width\": 2.5,\n",
+    "    \"limit\": 19.5,\n",
+    "    \"filter\": \"r\"\n",
+    "}\n",
+    "\n",
+    "# Display the JSON payload\n",
+    "print(json.dumps(payload_square, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-08",
+   "metadata": {},
+   "source": [
+    "Submit this pointing to the API:\n",
+    "\n",
+    "<span style=\"color: red;\">This cell is deliberately set to markdown format (rather than code) to prevent accidental submission of example data into the MPC's production database.</span>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-09",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "\"\"\"\n",
+    "This cell deliberately set to `markdown` format (rather than `code`) to reduce the risk of\n",
+    "accidental submission of example data into the MPC's production system.\n",
+    "\"\"\"\n",
+    "\n",
+    "# Submit the pointing\n",
+    "response = requests.post(url, json=payload_square)\n",
+    "\n",
+    "# Print the response\n",
+    "print(response.status_code)\n",
+    "print(response.reason)\n",
+    "print(response.text)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-10",
+   "metadata": {},
+   "source": [
+    "# Example 2: Circular Field (`fieldDiam`)\n",
+    "\n",
+    "This example demonstrates submitting a pointing for a circular field using the `fieldDiam` parameter (diameter in degrees).\n",
+    "\n",
+    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code below is displayed as markdown rather than an executable code cell.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "pointings-11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T00:48:12.022851Z",
+     "iopub.status.busy": "2026-09-04T00:48:12.022774Z",
+     "iopub.status.idle": "2026-09-04T00:48:12.024879Z",
+     "shell.execute_reply": "2026-09-04T00:48:12.024497Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"action\": \"exposed\",\n",
+      "  \"mode\": \"survey\",\n",
+      "  \"mpcCode\": \"802\",\n",
+      "  \"time\": \"2018-01-01T11:22:33.456\",\n",
+      "  \"duration\": 30,\n",
+      "  \"center\": [\n",
+      "    255.167,\n",
+      "    -29.008\n",
+      "  ],\n",
+      "  \"fieldDiam\": 2.45,\n",
+      "  \"limit\": 22,\n",
+      "  \"filter\": \"zp1\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build the JSON payload for a circular field\n",
+    "payload_circular = {\n",
+    "    \"action\": \"exposed\",\n",
+    "    \"mode\": \"survey\",\n",
+    "    \"mpcCode\": \"802\",\n",
+    "    \"time\": \"2018-01-01T11:22:33.456\",\n",
+    "    \"duration\": 30,\n",
+    "    \"center\": [255.167, -29.008],\n",
+    "    \"fieldDiam\": 2.45,\n",
+    "    \"limit\": 22,\n",
+    "    \"filter\": \"zp1\"\n",
+    "}\n",
+    "\n",
+    "# Display the JSON payload\n",
+    "print(json.dumps(payload_circular, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-12",
+   "metadata": {},
+   "source": [
+    "Submit this pointing to the API:\n",
+    "\n",
+    "<span style=\"color: red;\">This cell is deliberately set to markdown format (rather than code) to prevent accidental submission of example data into the MPC's production database.</span>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-13",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "\"\"\"\n",
+    "This cell deliberately set to `markdown` format (rather than `code`) to reduce the risk of\n",
+    "accidental submission of example data into the MPC's production system.\n",
+    "\"\"\"\n",
+    "\n",
+    "# Submit the pointing\n",
+    "response = requests.post(url, json=payload_circular)\n",
+    "\n",
+    "# Print the response\n",
+    "print(response.status_code)\n",
+    "print(response.reason)\n",
+    "print(response.text)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-14",
+   "metadata": {},
+   "source": [
+    "# Example 3: Tangent-Plane Offsets (`offsets`)\n",
+    "\n",
+    "This example demonstrates submitting a pointing using tangent-plane `offsets` to define the field corners. This is the most flexible geometry option, allowing arbitrarily shaped quadrilateral fields. Each offset is an `[RA, Dec]` pair in degrees relative to the field center.\n",
+    "\n",
+    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code below is displayed as markdown rather than an executable code cell.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "pointings-15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T00:48:12.025945Z",
+     "iopub.status.busy": "2026-09-04T00:48:12.025873Z",
+     "iopub.status.idle": "2026-09-04T00:48:12.028070Z",
+     "shell.execute_reply": "2026-09-04T00:48:12.027639Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"action\": \"exposed\",\n",
+      "  \"surveyExpName\": \"Kg101_abc23112233p456\",\n",
+      "  \"mode\": \"survey\",\n",
+      "  \"mpcCode\": \"802\",\n",
+      "  \"time\": \"2018-01-01T11:22:33.456\",\n",
+      "  \"duration\": 30,\n",
+      "  \"center\": [\n",
+      "    255.167,\n",
+      "    -29.008\n",
+      "  ],\n",
+      "  \"offsets\": [\n",
+      "    [\n",
+      "      1.25,\n",
+      "      -1.25\n",
+      "    ],\n",
+      "    [\n",
+      "      -1.25,\n",
+      "      -1.25\n",
+      "    ],\n",
+      "    [\n",
+      "      1.25,\n",
+      "      1.25\n",
+      "    ],\n",
+      "    [\n",
+      "      -1.25,\n",
+      "      1.25\n",
+      "    ]\n",
+      "  ],\n",
+      "  \"limit\": 22,\n",
+      "  \"filter\": \"r\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build the JSON payload using tangent-plane offsets\n",
+    "payload_offsets = {\n",
+    "    \"action\": \"exposed\",\n",
+    "    \"surveyExpName\": \"Kg101_abc23112233p456\",\n",
+    "    \"mode\": \"survey\",\n",
+    "    \"mpcCode\": \"802\",\n",
+    "    \"time\": \"2018-01-01T11:22:33.456\",\n",
+    "    \"duration\": 30,\n",
+    "    \"center\": [255.167, -29.008],\n",
+    "    \"offsets\": [\n",
+    "        [1.25, -1.25],\n",
+    "        [-1.25, -1.25],\n",
+    "        [1.25, 1.25],\n",
+    "        [-1.25, 1.25]\n",
+    "    ],\n",
+    "    \"limit\": 22,\n",
+    "    \"filter\": \"r\"\n",
+    "}\n",
+    "\n",
+    "# Display the JSON payload\n",
+    "print(json.dumps(payload_offsets, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-16",
+   "metadata": {},
+   "source": [
+    "Submit this pointing to the API:\n",
+    "\n",
+    "<span style=\"color: red;\">This cell is deliberately set to markdown format (rather than code) to prevent accidental submission of example data into the MPC's production database.</span>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-17",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "\"\"\"\n",
+    "This cell deliberately set to `markdown` format (rather than `code`) to reduce the risk of\n",
+    "accidental submission of example data into the MPC's production system.\n",
+    "\"\"\"\n",
+    "\n",
+    "# Submit the pointing\n",
+    "response = requests.post(url, json=payload_offsets)\n",
+    "\n",
+    "# Print the response\n",
+    "print(response.status_code)\n",
+    "print(response.reason)\n",
+    "print(response.text)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-18",
+   "metadata": {},
+   "source": [
+    "# Example 4: Targeted Follow-Up (`widths` + `mode=\"target\"` + `nonsidereal`)\n",
+    "\n",
+    "This example demonstrates submitting a pointing for a targeted follow-up observation of a specific object. It uses:\n",
+    "\n",
+    "- `widths` — defines a rectangular, equatorially-aligned field with separate RA and Dec side lengths (degrees)\n",
+    "- `mode: \"target\"` — indicates this is a targeted observation (requires `desig`)\n",
+    "- `desig` — the packed designation of the target object\n",
+    "- `nonsidereal: true` — indicates the telescope was not tracking sidereally\n",
+    "\n",
+    "<span style=\"color: red;\">To prevent accidental submission of example data into the MPC's production database, the submission code below is displayed as markdown rather than an executable code cell.</span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "pointings-19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-04T00:48:12.029186Z",
+     "iopub.status.busy": "2026-09-04T00:48:12.029109Z",
+     "iopub.status.idle": "2026-09-04T00:48:12.031132Z",
+     "shell.execute_reply": "2026-09-04T00:48:12.030782Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"action\": \"exposed\",\n",
+      "  \"surveyExpName\": \"20180101-EX0132\",\n",
+      "  \"mode\": \"target\",\n",
+      "  \"mpcCode\": \"802\",\n",
+      "  \"time\": \"2018-01-01T11:22:33.456\",\n",
+      "  \"duration\": 300,\n",
+      "  \"center\": [\n",
+      "    255.167,\n",
+      "    -29.008\n",
+      "  ],\n",
+      "  \"widths\": [\n",
+      "    0.82,\n",
+      "    0.64\n",
+      "  ],\n",
+      "  \"desig\": \"K18A00A\",\n",
+      "  \"limit\": 23.5,\n",
+      "  \"nonsidereal\": true,\n",
+      "  \"filter\": \"VR\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build the JSON payload for a targeted follow-up observation\n",
+    "payload_target = {\n",
+    "    \"action\": \"exposed\",\n",
+    "    \"surveyExpName\": \"20180101-EX0132\",\n",
+    "    \"mode\": \"target\",\n",
+    "    \"mpcCode\": \"802\",\n",
+    "    \"time\": \"2018-01-01T11:22:33.456\",\n",
+    "    \"duration\": 300,\n",
+    "    \"center\": [255.167, -29.008],\n",
+    "    \"widths\": [0.82, 0.64],\n",
+    "    \"desig\": \"K18A00A\",\n",
+    "    \"limit\": 23.5,\n",
+    "    \"nonsidereal\": True,\n",
+    "    \"filter\": \"VR\"\n",
+    "}\n",
+    "\n",
+    "# Display the JSON payload\n",
+    "print(json.dumps(payload_target, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-20",
+   "metadata": {},
+   "source": [
+    "Submit this pointing to the API:\n",
+    "\n",
+    "<span style=\"color: red;\">This cell is deliberately set to markdown format (rather than code) to prevent accidental submission of example data into the MPC's production database.</span>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-21",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "\"\"\"\n",
+    "This cell deliberately set to `markdown` format (rather than `code`) to reduce the risk of\n",
+    "accidental submission of example data into the MPC's production system.\n",
+    "\"\"\"\n",
+    "\n",
+    "# Submit the pointing\n",
+    "response = requests.post(url, json=payload_target)\n",
+    "\n",
+    "# Print the response\n",
+    "print(response.status_code)\n",
+    "print(response.reason)\n",
+    "print(response.text)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-22",
+   "metadata": {},
+   "source": [
+    "# Notes on Responses and Common Errors\n",
+    "\n",
+    "A successful submission returns a JSON response with the inserted record ID:\n",
+    "\n",
+    "```json\n",
+    "{\"response\": \"Inserted new record with ID=3708893\"}\n",
+    "```\n",
+    "\n",
+    "Common reasons for failed submissions include:\n",
+    "\n",
+    "- Missing required fields (e.g. `action`, `mode`, `mpcCode`, `time`, `duration`, `center`, `limit`)\n",
+    "- No field geometry specified (must provide exactly one of `width`, `widths`, `fieldDiam`, or `offsets`)\n",
+    "- Multiple field geometry fields provided simultaneously\n",
+    "- Missing `desig` when `mode` is `\"target\"`\n",
+    "- Invalid `mpcCode` (must be an MPC-assigned observatory code)\n",
+    "- Invalid `time` format (must be `YYYY-MM-DDThh:mm:ss.sss`)\n",
+    "\n",
+    "You can also submit pointings using cURL:\n",
+    "\n",
+    "```bash\n",
+    "curl -X POST -H \"Content-Type: application/json\" \\\n",
+    "  -d @json.txt https://www.minorplanetcenter.net/cgi-bin/pointings/submit\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pointings-23",
+   "metadata": {},
+   "source": [
+    "# Summary\n",
+    "\n",
+    "This tutorial demonstrated how to use the MPC Pointings API to submit telescope pointing information.\n",
+    "\n",
+    "- **API endpoint**: `https://www.minorplanetcenter.net/cgi-bin/pointings/submit`\n",
+    "- **Method**: `requests.post(url, json=payload)`\n",
+    "- **Required fields**: `action`, `surveyExpName`, `mode`, `mpcCode`, `time`, `duration`, `center`, `limit`\n",
+    "- **Field geometry** (exactly one): `width` (square), `widths` (rectangle), `fieldDiam` (circle), `offsets` (corners)\n",
+    "- **Target mode**: Set `mode=\"target\"` and provide `desig` for follow-up observations\n",
+    "\n",
+    "For more information, see:\n",
+    " - [Pointing submissions documentation](https://docs.minorplanetcenter.net/services/negative_observations/)\n",
+    " - [Negative Observations submission tutorial](mpc_tutorial_api_negative_observations.ipynb)\n",
+    "\n",
+    "For questions or feedback, contact the MPC via the [Jira Helpdesk](https://mpc-service.atlassian.net/servicedesk/customer/portal/13/create/148)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_pointings.ipynb
+++ b/docs-public/docs/tutorials/notebooks/mpc_tutorial_api_pointings.ipynb
@@ -571,7 +571,7 @@
     "\n",
     "```bash\n",
     "curl -X POST -H \"Content-Type: application/json\" \\\n",
-    "  -d @json.txt https://www.minorplanetcenter.net/cgi-bin/pointings/submit\n",
+    "  -d @payload.json https://www.minorplanetcenter.net/cgi-bin/pointings/submit\n",
     "```"
    ]
   },


### PR DESCRIPTION
## Summary

Closes two gaps found in an audit of API-tutorial coverage: both the Pointings API and the Negative Observations submission API had no tutorials on the [API tutorials page](https://docs.minorplanetcenter.net/tutorials/api_tutorials/).

- Pointings API tutorial 
- Negative Observations API tutorial 

N.B. These production endpoints have **no test mode** 
